### PR TITLE
Use Google Closure Templates 2015-04-10

### DIFF
--- a/tasks/soy.js
+++ b/tasks/soy.js
@@ -12,7 +12,7 @@ var fs=require('fs'),
 
 var classpathSeparator = /win32/i.test(process.platform) ? ';' : ':'; 
 
-var jarName = 'SoyToJsSrcCompiler.jar',
+var jarName = 'soy-2015-04-10-SoyToJsSrcCompiler.jar',
     jarLocation = path.join(__dirname, '../closure-templates-for-javascript-latest', jarName);
 
 var defaults = {


### PR DESCRIPTION
This aims to fix a disparity between the version of Google Closure Templates used in Mantle's `build.sbt` and all the other static tools and libraries in use in Mantle. Mantle's uses two versions:
`2015-04-10` and `2016-08-09`. The former in client side templates and the latter mostly in server side templates for delegate template support. TBH I have no idea what version is present in this library at the moment, but if I just upgrade the jars in Mantle the jar used here will stop working (classes missing from classpath). So I downloaded the `2015-04-10` version of `SoyToJsSrcCompiler.jar` from here: https://repo1.maven.org/maven2/com/google/template/soy/2015-04-10/ and made the version number explicit in the file name.

`<rant>`
Btw people who just copy unmanaged dependencies without even indicating the version number anywhere, at least a readme file or the commit message, should be ashamed of themselves. Also those who don't use pull requests and document what they did.
`</rant>`